### PR TITLE
Gradebook endpoints v2

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -59,6 +59,16 @@ functions:
           path: /api/v1/courses/{courseId}
 
   #
+  # Grade endpoints
+  #
+  getSessionGrade:
+    handler: src/handlers/grade.getSessionsGrades
+    events:
+      - http:
+          method: get
+          path: /api/v1/courses/{courseId}/grades
+
+          #
   # Folder endpoints
   #
   getFolder:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -61,14 +61,20 @@ functions:
   #
   # Grade endpoints
   #
-  getSessionGrade:
+  getSessionsGrades:
     handler: src/handlers/grade.getSessionsGrades
     events:
       - http:
           method: get
           path: /api/v1/courses/{courseId}/grades
+  getQuestionsGrades:
+    handler: src/handlers/grade.getQuestionsGrades
+    events:
+      - http:
+          method: get
+          path: /api/v1/courses/{courseId}/session/{sessionId}/grades
 
-          #
+  #
   # Folder endpoints
   #
   getFolder:

--- a/backend/src/@types/models/Session.d.ts
+++ b/backend/src/@types/models/Session.d.ts
@@ -5,6 +5,7 @@ interface SessionAttributes {
 	name: string;
 	userId: UserId;
 	courseId: CourseId;
+	Questions?: Question[];
 }
 
 interface SessionCreationAttributes {

--- a/backend/src/@types/util/CanvasStudent.d.ts
+++ b/backend/src/@types/util/CanvasStudent.d.ts
@@ -1,0 +1,5 @@
+interface CanvasStudent {
+	id: number;
+	name: string;
+	short_name: string;
+}

--- a/backend/src/handlers/grade.ts
+++ b/backend/src/handlers/grade.ts
@@ -75,3 +75,84 @@ export const getSessionsGrades = async (
 		});
 	}
 };
+
+// GET /api/v1/cousrses/:courseId/sessions/:sessionId/grades
+export const getQuestionsGrades = async (
+	event: APIGatewayEvent
+): Promise<ProxyResult> => {
+	const courseId = Number(event.pathParameters?.courseId);
+	const sessionId = Number(event.pathParameters?.sessionId);
+
+	try {
+		// Get all students belong to the current course from Canvas
+		const canvasStudents: CanvasStudent[] = await getStudents(
+			mockUserid,
+			courseId
+		);
+		const studentIds = await Promise.all(
+			canvasStudents.map(async (student: CanvasStudent) => {
+				const user = await User.findOne({ where: { canvasId: student.id } });
+
+				return user?.get().id;
+			})
+		);
+
+		// Get all questions belong to the current session
+		const session = await Session.findOne({
+			where: {
+				id: sessionId,
+			},
+			include: {
+				model: Question,
+			},
+		});
+
+		if (!session) {
+			return responses.notFound();
+		}
+		const questions = session.get().Questions?.map((question) => ({
+			id: question.get().id,
+			title: question.get().title,
+		}));
+		if (!questions) {
+			return responses.ok({
+				students: studentIds,
+				questions: [],
+			});
+		}
+
+		// Get individual grade for each question
+		const studentsGrades = await Promise.all(
+			studentIds.map(async (studentId, index) => {
+				const grades = await Promise.all(
+					questions.map(async (question) => {
+						const questionGrade = await QuestionGrade.findOne({
+							where: {
+								userId: studentId,
+								questionId: question.id,
+							},
+						});
+
+						return {
+							points: questionGrade?.get().points,
+							maxPoints: questionGrade?.get().maxPoints,
+						};
+					})
+				);
+
+				return {
+					name: canvasStudents[index].name,
+					grades: grades,
+				};
+			})
+		);
+		return responses.ok({
+			questions,
+			students: studentsGrades,
+		});
+	} catch (error) {
+		return responses.badRequest({
+			message: error || 'Fail to query',
+		});
+	}
+};

--- a/backend/src/handlers/grade.ts
+++ b/backend/src/handlers/grade.ts
@@ -27,7 +27,7 @@ export const getSessionsGrades = async (
 		// Get grades for each student
 		const students = await Promise.all(
 			canvasStudents.map(async (student: CanvasStudent) => {
-				return await User.findOne({
+				const user = await User.findOne({
 					attributes: ['canvasId'],
 					where: { canvasId: student.id },
 					include: {
@@ -38,6 +38,11 @@ export const getSessionsGrades = async (
 						},
 					},
 				});
+
+				return {
+					name: student.name,
+					...user?.get(),
+				};
 			})
 		);
 
@@ -82,7 +87,7 @@ export const getQuestionsGrades = async (
 		// Get grades for each student
 		const students = await Promise.all(
 			canvasStudents.map(async (student: CanvasStudent) => {
-				return await User.findOne({
+				const user = await User.findOne({
 					attributes: ['canvasId'],
 					where: { canvasId: student.id },
 					include: {
@@ -93,6 +98,11 @@ export const getQuestionsGrades = async (
 						},
 					},
 				});
+
+				return {
+					name: student.name,
+					...user?.get(),
+				};
 			})
 		);
 

--- a/backend/src/handlers/grade.ts
+++ b/backend/src/handlers/grade.ts
@@ -23,7 +23,6 @@ export const getSessionsGrades = async (
 			mockUserid,
 			courseId
 		);
-
 		const studentIds: number[] = await Promise.all(
 			canvasStudents.map(async (student: CanvasStudent) => {
 				const user = await User.findOne({ where: { canvasId: student.id } });
@@ -65,6 +64,7 @@ export const getSessionsGrades = async (
 				};
 			})
 		);
+
 		return responses.ok({
 			students: studentGrades,
 			sessions,
@@ -92,7 +92,6 @@ export const getQuestionsGrades = async (
 		const studentIds: number[] = await Promise.all(
 			canvasStudents.map(async (student: CanvasStudent) => {
 				const user = await User.findOne({ where: { canvasId: student.id } });
-
 				return Number(user?.get().id);
 			})
 		);
@@ -139,6 +138,7 @@ export const getQuestionsGrades = async (
 				};
 			})
 		);
+
 		return responses.ok({
 			questions,
 			students: studentsGrades,

--- a/backend/src/handlers/grade.ts
+++ b/backend/src/handlers/grade.ts
@@ -1,0 +1,77 @@
+import { APIGatewayEvent, ProxyResult } from 'aws-lambda';
+import {
+	Question,
+	QuestionGrade,
+	Session,
+	SessionGrade,
+	User,
+} from '../models';
+import responses from '../util/api/responses';
+import { getStudents } from '../util/canvas';
+
+const mockUserid = 1;
+
+// GET /api/v1/cousrses/:courseId/grades
+export const getSessionsGrades = async (
+	event: APIGatewayEvent
+): Promise<ProxyResult> => {
+	const courseId = Number(event.pathParameters?.courseId);
+
+	try {
+		// Get all students belong to the current course from Canvas
+		const canvasStudents: CanvasStudent[] = await getStudents(
+			mockUserid,
+			courseId
+		);
+
+		const studentIds = await Promise.all(
+			canvasStudents.map(async (student: CanvasStudent) => {
+				const user = await User.findOne({ where: { canvasId: student.id } });
+				return user?.get().id;
+			})
+		);
+
+		// Get all sessions belong to the current course
+		const sessions = (
+			await Session.findAll({
+				where: {
+					courseId: courseId,
+				},
+			})
+		).map((session) => ({ id: session.get().id, name: session.get().name }));
+
+		// Get individual grade for each session
+		const studentGrades = await Promise.all(
+			studentIds.map(async (studentId, index) => {
+				const grades = await Promise.all(
+					sessions.map(async (session) => {
+						const grade = await SessionGrade.findOne({
+							where: {
+								userId: studentId,
+								sessionId: session.id,
+							},
+						});
+
+						return {
+							points: grade?.get().points,
+							maxPoints: grade?.get().maxPoints,
+						};
+					})
+				);
+
+				return {
+					name: canvasStudents[index].name,
+					grades: grades,
+				};
+			})
+		);
+		return responses.ok({
+			students: studentGrades,
+			sessions,
+		});
+	} catch (error) {
+		return responses.badRequest({
+			message: error || 'Fail to query',
+		});
+	}
+};

--- a/backend/src/handlers/grade.ts
+++ b/backend/src/handlers/grade.ts
@@ -24,10 +24,10 @@ export const getSessionsGrades = async (
 			courseId
 		);
 
-		const studentIds = await Promise.all(
+		const studentIds: number[] = await Promise.all(
 			canvasStudents.map(async (student: CanvasStudent) => {
 				const user = await User.findOne({ where: { canvasId: student.id } });
-				return user?.get().id;
+				return Number(user?.get().id);
 			})
 		);
 
@@ -42,7 +42,7 @@ export const getSessionsGrades = async (
 
 		// Get individual grade for each session
 		const studentGrades = await Promise.all(
-			studentIds.map(async (studentId, index) => {
+			studentIds.map(async (studentId: number, index: number) => {
 				const grades = await Promise.all(
 					sessions.map(async (session) => {
 						const grade = await SessionGrade.findOne({
@@ -89,11 +89,11 @@ export const getQuestionsGrades = async (
 			mockUserid,
 			courseId
 		);
-		const studentIds = await Promise.all(
+		const studentIds: number[] = await Promise.all(
 			canvasStudents.map(async (student: CanvasStudent) => {
 				const user = await User.findOne({ where: { canvasId: student.id } });
 
-				return user?.get().id;
+				return Number(user?.get().id);
 			})
 		);
 
@@ -106,7 +106,6 @@ export const getQuestionsGrades = async (
 				model: Question,
 			},
 		});
-
 		if (!session) {
 			return responses.notFound();
 		}
@@ -114,18 +113,12 @@ export const getQuestionsGrades = async (
 			id: question.get().id,
 			title: question.get().title,
 		}));
-		if (!questions) {
-			return responses.ok({
-				students: studentIds,
-				questions: [],
-			});
-		}
 
 		// Get individual grade for each question
 		const studentsGrades = await Promise.all(
-			studentIds.map(async (studentId, index) => {
+			studentIds.map(async (studentId: number, index: number) => {
 				const grades = await Promise.all(
-					questions.map(async (question) => {
+					(questions || []).map(async (question) => {
 						const questionGrade = await QuestionGrade.findOne({
 							where: {
 								userId: studentId,

--- a/backend/src/util/api/responses.ts
+++ b/backend/src/util/api/responses.ts
@@ -75,4 +75,18 @@ export default {
 			body: JSON.stringify(data || {}),
 		};
 	},
+	/**
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+	 */
+	notFound(data?: unknown): APIGatewayProxyResult {
+		return {
+			headers: {
+				'Content-Type': 'application/json',
+				'Access-Control-Allow-Methods': '*',
+				'Access-Control-Allow-Origin': '*',
+			},
+			statusCode: 404,
+			body: JSON.stringify(data || {}),
+		};
+	},
 };

--- a/backend/src/util/canvas.ts
+++ b/backend/src/util/canvas.ts
@@ -3,45 +3,55 @@ import querystring from 'querystring';
 import { User } from '../models';
 
 const getToken = async (userId: number): Promise<string> => {
-	const user = await User.findOne({
-		where: {
-			id: userId,
-		},
-	});
+	try {
+		const user = await User.findOne({
+			where: {
+				id: userId,
+			},
+		});
 
-	const res = await fetch(
-		`${process.env.CANVAS_URL}/login/oauth2/token?` +
-			querystring.encode({
-				grant_type: 'refresh_token',
-				client_id: process.env.CANVAS_ID,
-				client_secret: process.env.CANVAS_KEY,
-				refresh_token: user?.get().refreshToken,
-			}),
-		{
-			method: 'POST',
-		}
-	);
+		const res = await fetch(
+			`${process.env.CANVAS_URL}/login/oauth2/token?` +
+				querystring.encode({
+					grant_type: 'refresh_token',
+					client_id: process.env.CANVAS_ID,
+					client_secret: process.env.CANVAS_KEY,
+					refresh_token: user?.get().refreshToken,
+				}),
+			{
+				method: 'POST',
+			}
+		);
 
-	const data = await res.json();
-	return data.access_token;
+		const data = await res.json();
+		return data.access_token;
+	} catch (error) {
+		console.log('Error while fetching token:', error);
+		return Promise.reject(error);
+	}
 };
 
 export const getStudents = async (
 	userId: number,
 	courseId: number
 ): Promise<CanvasStudent[]> => {
-	const token = await getToken(userId);
-	const res = await fetch(
-		`${process.env.CANVAS_URL}/api/v1/courses/${courseId}/students`,
-		{
-			method: 'GET',
-			headers: {
-				Authorization: `Bearer ${token}`,
-			},
-		}
-	);
+	try {
+		const token = await getToken(userId);
+		const res = await fetch(
+			`${process.env.CANVAS_URL}/api/v1/courses/${courseId}/students`,
+			{
+				method: 'GET',
+				headers: {
+					Authorization: `Bearer ${token}`,
+				},
+			}
+		);
 
-	const data: CanvasStudent[] = await res.json();
+		const data: CanvasStudent[] = await res.json();
 
-	return data;
+		return data;
+	} catch (error) {
+		console.log('Error while fetching students:', error);
+		return Promise.reject(error);
+	}
 };

--- a/backend/src/util/canvas.ts
+++ b/backend/src/util/canvas.ts
@@ -6,7 +6,7 @@ const getToken = async (userId: number): Promise<string> => {
 	try {
 		const user = await User.findOne({
 			where: {
-				id: userId,
+				canvasId: userId,
 			},
 		});
 

--- a/backend/src/util/canvas.ts
+++ b/backend/src/util/canvas.ts
@@ -1,0 +1,47 @@
+import fetch from 'node-fetch';
+import querystring from 'querystring';
+import { User } from '../models';
+
+const getToken = async (userId: number): Promise<string> => {
+	const user = await User.findOne({
+		where: {
+			id: userId,
+		},
+	});
+
+	const res = await fetch(
+		`${process.env.CANVAS_URL}/login/oauth2/token?` +
+			querystring.encode({
+				grant_type: 'refresh_token',
+				client_id: process.env.CANVAS_ID,
+				client_secret: process.env.CANVAS_KEY,
+				refresh_token: user?.get().refreshToken,
+			}),
+		{
+			method: 'POST',
+		}
+	);
+
+	const data = await res.json();
+	return data.access_token;
+};
+
+export const getStudents = async (
+	userId: number,
+	courseId: number
+): Promise<CanvasStudent[]> => {
+	const token = await getToken(userId);
+	const res = await fetch(
+		`${process.env.CANVAS_URL}/api/v1/courses/${courseId}/students`,
+		{
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${token}`,
+			},
+		}
+	);
+
+	const data: CanvasStudent[] = await res.json();
+
+	return data;
+};


### PR DESCRIPTION
Resolve #86

Improve query for gradebook.
Return example:
```json
{
    "sessions": [
        {
            "id": 1,
            "name": "Session 1"
        },
        {
            "id": 2,
            "name": "Session 2"
        }
    ],
    "students": [
        {
            "name": "Student1",
            "canvasId": 2,
            "SessionGrades": [
                {
                    "id": 1,
                    "points": 8,
                    "maxPoints": 10
                },
                {
                    "id": 3,
                    "points": 9.3,
                    "maxPoints": 10
                }
            ]
        },
        {
            "name": "Student2",
            "canvasId": 6,
            "SessionGrades": [
                {
                    "id": 2,
                    "points": 8,
                    "maxPoints": 10
                },
                {
                    "id": 4,
                    "points": 7,
                    "maxPoints": 10
                }
            ]
        }
    ]
}
```