### PR TITLE
Add Serverless token authorizer middleware

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -49,6 +49,12 @@ functions:
     handler: src/handlers/db/index.drop
 
   #
+  # Authorizer functions
+  #
+  tokenAuthorizer:
+    handler: src/handlers/auth/authorizer.tokenAuthorizer
+
+  #
   # Course endpoints
   #
   getCourse:
@@ -57,6 +63,7 @@ functions:
       - http:
           method: get
           path: /api/v1/courses/{courseId}
+          authorizer: tokenAuthorizer
 
   #
   # Grade endpoints
@@ -67,18 +74,21 @@ functions:
       - http:
           method: get
           path: /api/v1/courses/{courseId}/grades
+          authorizer: tokenAuthorizer
   getQuestionsGrades:
     handler: src/handlers/grade.getQuestionsGrades
     events:
       - http:
           method: get
           path: /api/v1/courses/{courseId}/session/{sessionId}/grades
+          authorizer: tokenAuthorizer
   exportGrades:
     handler: src/handlers/grade.exportGrades
     events:
       - http:
           method: post
           path: /api/v1/courses/{courseId}/grades_export
+          authorizer: tokenAuthorizer
 
 
   #
@@ -90,24 +100,28 @@ functions:
       - http:
           method: get
           path: /api/v1/folder/{folderId}
+          authorizer: tokenAuthorizer
   newFolder:
     handler: src/handlers/folder.create
     events:
       - http:
           method: post
           path: /api/v1/folder
+          authorizer: tokenAuthorizer
   updateFolder:
     handler: src/handlers/folder.update
     events:
       - http:
           method: put
           path: /api/v1/folder/{folderId}
+          authorizer: tokenAuthorizer
   deleteFolder:
     handler: src/handlers/folder.remove
     events:
       - http:
           method: delete
           path: /api/v1/folder/{folderId}
+          authorizer: tokenAuthorizer
 
   #
   # Session endpoints
@@ -118,12 +132,14 @@ functions:
       - http:
           method: get
           path: /api/v1/session/{sessionId}
+          authorizer: tokenAuthorizer
   createSession:
     handler: src/handlers/session.create
     events:
       - http:
           method: post
           path: /api/v1/session
+          authorizer: tokenAuthorizer
 
   #
   # Question endpoints
@@ -134,24 +150,28 @@ functions:
       - http:
           method: get
           path: /api/v1/question/{questionId}
+          authorizer: tokenAuthorizer
   createQuestion:
     handler: src/handlers/question.create
     events:
       - http:
           method: post
           path: /api/v1/question
+          authorizer: tokenAuthorizer
   updateQuestion:
     handler: src/handlers/question.update
     events:
       - http:
           method: put
           path: /api/v1/question/{questionId}
+          authorizer: tokenAuthorizer
   deleteQuestion:
     handler: src/handlers/question.remove
     events:
       - http:
           method: delete
           path: /api/v1/question/{questionId}
+          authorizer: tokenAuthorizer
 
   #
   # Question Option endpoints
@@ -162,18 +182,21 @@ functions:
       - http:
           method: post
           path: /api/v1/question/{questionId}/option
+          authorizer: tokenAuthorizer
   updateQuestionOption:
     handler: src/handlers/question_option.update
     events:
       - http:
           method: put
           path: /api/v1/question/{questionId}/option/{optionId}
+          authorizer: tokenAuthorizer
   deleteQuestionOption:
     handler: src/handlers/question_option.remove
     events:
       - http:
           method: delete
           path: /api/v1/question/{questionId}/option/{optionId}
+          authorizer: tokenAuthorizer
 
   #
   # Question User Response endpoints
@@ -184,24 +207,28 @@ functions:
       - http:
           method: post
           path: /api/v1/question/{questionId}/response
+          authorizer: tokenAuthorizer
   deleteQuestionUserResponse:
     handler: src/handlers/question_user_response.remove
     events:
       - http:
           method: delete
           path: /api/v1/question/{questionId}/response
+          authorizer: tokenAuthorizer
   updateQuestionUserResponse:
     handler: src/handlers/question_user_response.update
     events:
       - http:
           method: put
           path: /api/v1/question/{questionId}/response
+          authorizer: tokenAuthorize
   getQuestionUserResponse:
     handler: src/handlers/question_user_response.get
     events:
       - http:
           method: get
           path: /api/v1/question/{questionId}/response
+          authorizer: tokenAuthorizer
 
   #
   # Auth
@@ -295,6 +322,7 @@ functions:
           path: /api/v1/user/setting
           method: get
           cors: true
+          authorizer: tokenAuthorizer
   setUserSetting:
     handler: src/handlers/user.setUserSetting
     events:
@@ -302,6 +330,7 @@ functions:
           path: /api/v1/user/setting
           method: put
           cors: true
+          authorizer: tokenAuthorizer
 
   #
   # websocket endpoints

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -39,6 +39,12 @@ functions:
       - http:
           method: get
           path: hello
+  mockLtiLaunch:
+    handler: src/handlers/mock.launch
+    events:
+      - http:
+          method: get
+          path: mock_launch
 
   #
   # script functions
@@ -221,7 +227,7 @@ functions:
       - http:
           method: put
           path: /api/v1/question/{questionId}/response
-          authorizer: tokenAuthorize
+          authorizer: tokenAuthorizer
   getQuestionUserResponse:
     handler: src/handlers/question_user_response.get
     events:

--- a/backend/src/handlers/auth/authorizer.ts
+++ b/backend/src/handlers/auth/authorizer.ts
@@ -12,6 +12,7 @@ export const tokenAuthorizer = async (
 	callback: Callback
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> => {
+	// Missing token, reject request
 	if (!event.authorizationToken) {
 		return callback(null, {
 			principalId: 'user',

--- a/backend/src/handlers/auth/authorizer.ts
+++ b/backend/src/handlers/auth/authorizer.ts
@@ -1,0 +1,64 @@
+import {
+	APIGatewayTokenAuthorizerEvent,
+	Context,
+	Callback,
+	PolicyDocument,
+} from 'aws-lambda';
+import { decode } from '../../util/token';
+
+export const tokenAuthorizer = async (
+	event: APIGatewayTokenAuthorizerEvent,
+	_context: Context,
+	callback: Callback
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> => {
+	if (!event.authorizationToken) {
+		return callback(null, {
+			principalId: 'user',
+			policyDocument: getPolicyDocument('Deny', event.methodArn),
+		});
+	}
+
+	try {
+		const token = event.authorizationToken.split(' ')[1];
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const user: any = decode(token);
+
+		// Invalid token, reject request
+		if (!user) {
+			return callback(null, {
+				principalId: 'user',
+				policyDocument: getPolicyDocument('Deny', event.methodArn),
+			});
+		}
+
+		// Valid token, forward to request
+		callback(null, {
+			principalId: user.canvasId,
+			policyDocument: getPolicyDocument('Allow', event.methodArn),
+			context: user,
+		});
+	} catch (error) {
+		return callback(null, {
+			principalId: 'user',
+			policyDocument: getPolicyDocument('Deny', event.methodArn),
+		});
+	}
+};
+
+const getPolicyDocument = (
+	effect: string,
+	resource: string
+): PolicyDocument => {
+	return {
+		Version: '2012-10-17',
+		Statement: [
+			{
+				Action: 'execute-api:Invoke',
+				Effect: effect,
+				Resource: resource,
+			},
+		],
+	};
+};

--- a/backend/src/handlers/mock.ts
+++ b/backend/src/handlers/mock.ts
@@ -1,0 +1,34 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+
+import { User } from '../models';
+import responses from '../util/api/responses';
+import { encode } from '../util/token';
+
+// declare lambda function
+export const launch: APIGatewayProxyHandler = async () => {
+	const devUserId = 1;
+	const devCourseId = 1;
+	try {
+		let user = await User.findOne({
+			where: {
+				canvasId: 1,
+			},
+		});
+
+		if (!user) {
+			user = await User.create({
+				canvasId: devUserId,
+				token: '',
+				refreshToken: '',
+			});
+		}
+
+		const token = encode(user.get());
+
+		return responses.movedPermanently(
+			`http://localhost:3000/course/${devCourseId}/?token=${token}`
+		);
+	} catch (error) {
+		return responses.internalServerError(error);
+	}
+};

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,7 +22,7 @@ Runs eslint and prettier on the frontend files in `src/`.
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [localhost:3000/course/1?token=123456789](localhost:3000/course/1?token=123456789) to view it in the browser.
+Open [localhost:5000/dev/mock_launch](localhost:5000/dev/mock_launch) to view it in the browser.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
@@ -78,7 +78,7 @@ REACT_APP_WEBSOCKET_URL="ws://localhost:3001"
 
 The frontend is authenticated through a redirect in Canvas. It is `<base url>/course/<courseId>?token=<jwt>`
 
-If you want to access the frontend locally you will need to navigate to `https://localhost:3000/course/<courseId>?token=<data of your choice>`
+If you want to access the frontend locally you will need to navigate to `http://localhost:5000/dev/mock_launch`. This enpoint will simulate a LTI launch
 
 ## Learn More
 


### PR DESCRIPTION
Rest API endpoints will now require a valid token.

For frontend local dev, use: http://localhost:5000/dev/mock_launch to fake a lti launch. It has 1 as the default userId and courseId